### PR TITLE
fix syntax error for embedded quotes around MH

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE rfc PUBLIC "-//IETF//DTD RFC 2629//EN" "http://xml.resource.org/authoring/rfc2629.dtd" [
   <!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
   <!ENTITY rfc6234 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6234.xml">
+  <!ENTITY rfc7693 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7693.xml">
   <!ENTITY rfc6150 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6150.xml">
   <!ENTITY rfc6151 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6151.xml">
-  <!ENTITY rfc7693 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7693.xml">
 ]>
 <?xml-stylesheet type="text/xsl" href="rfc2629.xsl" ?>
 <?rfc compact="yes" ?>

--- a/index.xml
+++ b/index.xml
@@ -501,7 +501,7 @@ NOTE: The most up to date place for developers to find the table above is
       </t>
     </section>
     
-    <section anchor="mh-digest-algorithm" title="The "MH" Digest Algorithm">
+    <section anchor="mh-digest-algorithm" title="The &quot;MH&quot; Digest Algorithm">
       <t>
         This memo registers the "MH" digest algorithm in the 
         <eref target="https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml">HTTP Digest Algorithm Values</eref>


### PR DESCRIPTION
Create some syntax changes :

```
<section anchor="mh-digest-algorithm" title="The "MH" Digest Algorithm">
```

to
```
<section anchor="mh-digest-algorithm" title="The &quot; MH&quot;  Digest Algorithm">
```
