### PR TITLE
Add multihash to the NI hash registry

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -734,6 +734,21 @@ NOTE: The most up to date place for developers to find the table above is
         <t>Status: standard</t>
 
     </section>
+
+    <section anchor="mh-ni-hash-algorithm" title="The 'mh' Named Information Hash Algorithm">
+      <t>
+        This memo registers the "mh" hash algorithm in the
+        <eref target="https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg">Named Information Hash Algorithm</eref>
+        registry with the following values:
+      </t>
+
+        <t>ID: 49</t>
+        <t>Hash Name String: mh</t>
+        <t>Value Length: variable</t>
+        <t>Reference: this document</t>
+        <t>Status: current</t>
+
+    </section>
   </section>
 </back>
 </rfc>


### PR DESCRIPTION
This adds multihash to the registry for the `ni:` and `nih:` URI schemes, allowing its use in general URIs referencing objects by their hash.

The `mh` name was chosen for consistency with the other registration in the HTTP Digest Algorithm Values registry.

The ID of 49 is taken from the identification of multihash itself in the multicodec table, for possible use in the binary format specified by RFC 6920. Sharing the identifier is not necessary in itself, but it ensures that it is not confused with an actual existing multihash identifier in the binary representation.

It should be noted that the digest value in `ni:` is encoded using the base64url encoding, with no `=` padding characters.