### PR TITLE
adding LEB128 normative reference from earlier @jasnell draft

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -137,6 +137,15 @@ data format.
       <section anchor="cdt-uvi" title="unsigned variable integer">
         <t>
 A data type that enables one to express an unsigned integer of variable length.
+It is defined in Appendix C of the 1993 <xref target="RFC6234">LEB128</xref>
+standard.
+        </t>
+        <t>
+As suggested by the name, this variable length encoding is only capable of
+representing unsigned integers.  Further, while there is no theoretical maximum
+integer value that can be represented by the format, implementations MUST NOT
+encode more than nine (9) bytes giving a practical limit of integers in a range
+between 0 and 2^63 - 1.
         </t>
         <t>
 When encoding an unsigned variable integer, the unsigned integer is serialized
@@ -222,6 +231,18 @@ data specifies the value of the output of the hash function.
 
 <back>
   <references title="Normative References">
+    <reference anchor="LEB128" target="http://dwarfstd.org/doc/Dwarf3.pdf">
+      <front>
+        <title>DWARF Debugging Information Format</title>
+        <author fullname="DWARF Debugging Information Format Workgroup"/>
+        <date month="December" year="2005"/>
+        <abstract>
+          <t>The LEB128 standard is defined by Appendix C, with parser
+          pseudocode.</t>
+        </abstract>
+      </front>
+    </reference>
+            
     <reference anchor="RFC6234" target="https://www.rfc-editor.org/info/rfc6234">
       <front>
         <title>US Secure Hash Algorithms (SHA and SHA-based HMAC and HKDF)</title>
@@ -235,6 +256,7 @@ data specifies the value of the output of the hash function.
       <seriesInfo name="RFC" value="6234"/>
       <seriesInfo name="DOI" value="10.17487/RFC6234"/>
     </reference>
+    
     <reference anchor="RFC7693" target="https://www.rfc-editor.org/info/rfc7693">
       <front>
         <title>The BLAKE2 Cryptographic Hash and Message Authentication Code (MAC)</title>


### PR DESCRIPTION
I think an IETF WG might want to consider where the unsigned_varint needs to be mandated for all implementations, or if conventional binary formats might be OK for encoding lengths. 